### PR TITLE
Suggestion: Use dotenv to pull api key from .env file

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,12 +9,13 @@ from flask import (
 from werkzeug.utils import secure_filename
 from PIL import Image
 import io
+import os
 
 import google.generativeai as genai
 
 # WARNING: Do not share code with you API key hard coded in it.
 # Get your Gemini API key from: https://aistudio.google.com/app/apikey
-GOOGLE_API_KEY=""
+GOOGLE_API_KEY=os.environ.get('GOOGLE_API_KEY')
 genai.configure(api_key=GOOGLE_API_KEY)
 
 # The rate limits are low on this model, so you might need to switch to `gemini-pro`

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyasn1_modules==0.4.0
 pydantic==2.7.1
 pydantic_core==2.18.2
 pyparsing==3.1.2
-python-dotenv
+python-dotenv==1.0.1
 requests==2.31.0
 rsa==4.9
 tqdm==4.66.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pyasn1_modules==0.4.0
 pydantic==2.7.1
 pydantic_core==2.18.2
 pyparsing==3.1.2
+python-dotenv
 requests==2.31.0
 rsa==4.9
 tqdm==4.66.4


### PR DESCRIPTION
Just a suggestion PR with the changes I made to pull the API key from the .env file! May make it a simpler for folks to run out-of-the-box once they add their key.

**Changes**:
- Uses dotenv package to pull key frrom .env file 
- Adds dotenv to requirements.txt 